### PR TITLE
cleopatra v0.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.9.0" %}
+{% set version = "0.10.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: 0fb41878399671ba00bdc0629d82c4fc95afd204dc1cd8ceef2297f2796898c3
+  sha256: b2273f7978ad30e85ce742e5a713db394bd7001e9536d9a196287fc4581dfdb1
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.10.1.

Changes to `recipe/meta.yaml`:
- `version`: 0.9.0 → 0.10.1
- `sha256`: updated to match the `0.10.1` source tarball (`b2273f7978ad30e85ce742e5a713db394bd7001e9536d9a196287fc4581dfdb1`, verified against `https://github.com/serapeum-org/cleopatra/archive/0.10.1.tar.gz`)
- build number stays 0 (new version)

No dependency changes between 0.9.0 and 0.10.1: the `pyproject.toml` dependency set (numpy>=2.0.0, matplotlib>=3.9, ffmpeg-python, hpc-utils>=0.1.4, and the `tiles` extras) is unchanged, so `requirements`/`run_constrained` are untouched.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged