### PR TITLE
cleopatra v0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.9.0" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: 0fb41878399671ba00bdc0629d82c4fc95afd204dc1cd8ceef2297f2796898c3
+  sha256: 08e7cae2155bc766f58fc204103471be84f8a0c988137689b70a08be03cc266c
 
 build:
   number: 0


### PR DESCRIPTION
Packages `cleopatra` v0.10.0 (previously skipped on the feedstock).

Changes to `recipe/meta.yaml`:
- `version`: 0.9.0 → 0.10.0
- `sha256`: `08e7cae2155bc766f58fc204103471be84f8a0c988137689b70a08be03cc266c` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.10.0.tar.gz`)
- build number stays 0 (new version)

No dependency changes vs 0.9.0: `pyproject.toml` deps (numpy>=2.0.0, matplotlib>=3.9, ffmpeg-python, hpc-utils>=0.1.4, and the `tiles` extras) are unchanged.

Note: 0.10.1 is the newest release (see #12). 0.10.0 < 0.10.1 by conda version ordering, so merging this does not supersede 0.10.1 as the default-installed version.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged