### PR TITLE
cleopatra v0.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.14.0" %}
+{% set version = "0.15.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: 8d521f8cdca36ad399b4e0605390cd9635439c0d6b06cb5bcf954d71b972ba1c
+  sha256: c3fdb180caa05dc990a7091106f470a33c49f29f50a5bd47cdfb7fae09eaa1a2
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.15.0.

Changes to `recipe/meta.yaml`:
- `version`: 0.14.0 → 0.15.0
- `sha256`: `c3fdb180caa05dc990a7091106f470a33c49f29f50a5bd47cdfb7fae09eaa1a2` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.15.0.tar.gz`)
- build number stays 0 (new version)

No dependency changes vs 0.14.0: `pyproject.toml` deps (numpy>=2.0.0, matplotlib>=3.9, ffmpeg-python, hpc-utils>=0.1.4, and the `tiles` extras) are unchanged, so `requirements`/`run_constrained` are untouched.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged