### PR TITLE
cleopatra v0.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.16.0" %}
+{% set version = "0.17.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: ff9194d990b1aa31ad4f851136ad6fc8304b58377bcfa25711435e2b671e9200
+  sha256: d4e18f7e8b7ecde68d95f4281bc40a55c48594168d355722cf059d8ebf89c631
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.17.0.

Changes to `recipe/meta.yaml`:
- `version`: 0.16.0 → 0.17.0
- `sha256`: `d4e18f7e8b7ecde68d95f4281bc40a55c48594168d355722cf059d8ebf89c631` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.17.0.tar.gz`)
- build number stays 0 (new version)

Dependency alignment with `pyproject.toml` verified:
- Core deps unchanged: numpy>=2.0.0, matplotlib>=3.9, ffmpeg-python, hpc-utils>=0.1.4 (conda: `hpc`).
- `tiles` extra unchanged: mercantile>=1.2.1, pillow>=12.1.1, pyproj>=3.7.2, xyzservices>=2026.3.0.
- The new Natural Earth / relief reference helpers (`cleopatra.reference`) add no new declared dependencies: networking uses the stdlib (`urllib`/`gzip`/`json`), and `PIL`/`pyproj` are imported lazily and are already covered by the `tiles` extra.

So `requirements`/`run_constrained` need no changes.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged