### PR TITLE
cleopatra v0.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.18.0" %}
+{% set version = "0.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: 959b9340b32daa68276f0fc385cf100e0ece67b0385fb3a73921fa91c432364d
+  sha256: 53c0211ffd0ffa1e0975ad427dfd6b4846acfa5661848dc59e04d5c4de3d017e
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.19.0.

Changes to `recipe/meta.yaml`:
- `version`: 0.18.0 → 0.19.0
- `sha256`: `53c0211ffd0ffa1e0975ad427dfd6b4846acfa5661848dc59e04d5c4de3d017e` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.19.0.tar.gz`)
- build number stays 0 (new version)

No dependency changes vs 0.18.0: `pyproject.toml` deps (numpy>=2.0.0, matplotlib>=3.9, ffmpeg-python, hpc-utils>=0.1.4, and the `tiles` extras) are unchanged, so `requirements`/`run_constrained` are untouched.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged