### PR TITLE
cleopatra v0.24.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.23.0" %}
+{% set version = "0.24.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: d0d192532d4b17679d8b74e7c66fdd66f13383a09f8efa3ea8d13a2164cdf0bf
+  sha256: 8a1b616666936a00a25b4e3941e8a1785892bf67045abb0af45da5013a7cd8d8
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.24.0.

Changes to `recipe/meta.yaml`:
- `version`: 0.23.0 → 0.24.0
- `sha256`: `8a1b616666936a00a25b4e3941e8a1785892bf67045abb0af45da5013a7cd8d8` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.24.0.tar.gz`)
- build number stays 0 (new version)

No dependency changes vs 0.23.0: `pyproject.toml` deps (numpy>=2.0.0, matplotlib>=3.9, imageio-ffmpeg>=0.4.9, hpc-utils>=0.1.4, and the `tiles` extras) are unchanged — diffed directly against 0.23.0's `pyproject.toml` to confirm only the version string changed.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged