### PR TITLE
cleopatra v0.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.25.0" %}
+{% set version = "0.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: d243da42bc013ca92e37f29f6143ede382c61552616b0a2596225c288cc13748
+  sha256: f7fad44417e63086543c271ce96c222a92d4e3691bdd16fe23b566572a947b6c
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.26.0.

Changes to `recipe/meta.yaml`:
- `version`: 0.25.0 → 0.26.0
- `sha256`: `f7fad44417e63086543c271ce96c222a92d4e3691bdd16fe23b566572a947b6c` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.26.0.tar.gz`)
- build number stays 0 (new version)

No dependency changes vs 0.25.0: `pyproject.toml` deps (numpy>=2.0.0, matplotlib>=3.9, imageio-ffmpeg>=0.4.9, hpc-utils>=0.1.4, and the `tiles` extras) are unchanged — diffed directly against 0.25.0's `pyproject.toml` to confirm only the version string changed.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged