### PR TITLE
cleopatra v0.26.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "cleopatra" %}
-{% set version = "0.26.0" %}
+{% set version = "0.26.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/cleopatra/archive/{{ version }}.tar.gz
-  sha256: f7fad44417e63086543c271ce96c222a92d4e3691bdd16fe23b566572a947b6c
+  sha256: 2eeb9ef4e77826ff1d2b281223b15154f57f74ec1bfaf0a80590197cf71610ca
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `cleopatra` to v0.26.1.

Changes to `recipe/meta.yaml`:
- `version`: 0.26.0 → 0.26.1
- `sha256`: `2eeb9ef4e77826ff1d2b281223b15154f57f74ec1bfaf0a80590197cf71610ca` (verified against `https://github.com/serapeum-org/cleopatra/archive/0.26.1.tar.gz`)
- build number stays 0 (new version)

Dependency alignment verified against 0.26.1's `pyproject.toml` (full side-by-side, not just a version-diff):

| pyproject.toml | meta.yaml |
|---|---|
| numpy>=2.0.0 | numpy >=2.0.0 |
| matplotlib>=3.9 | matplotlib >=3.9 |
| imageio-ffmpeg>=0.4.9 | imageio-ffmpeg >=0.4.9 |
| hpc-utils>=0.1.4 | hpc >=0.1.4 (PyPI→conda name map) |
| tiles: mercantile/pillow/pyproj/xyzservices | all match |
| requires-python >=3.11,<4 | python >=3.11 |

No dependency changes vs 0.26.0.

Checklist:
- [x] Dependencies updated if changed (no changes)
- [ ] Tests pass (CI)
- [x] License unchanged